### PR TITLE
Switch to using a Git abbreviated commit instead of BUILD_NUMBER

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,18 @@
 #!groovy
 
 def imageName = 'jenkinsciinfra/bind'
-def imageTag = "build${env.BUILD_NUMBER}"
 
 node('docker') {
     checkout scm
+
+    /* Using this hack right now to grab the appropriate abbreviated SHA1 of
+     * our current build's commit. We must do this because right now I cannot
+     * refer to `env.GIT_COMMIT` in Pipeline scripts
+     */
+    sh 'git rev-parse HEAD > GIT_COMMIT'
+    shortCommit = readFile('GIT_COMMIT').take(6)
+    def imageTag = "build${shortCommit}"
+
 
     stage 'Build'
     def whale = docker.build("${imageName}:${imageTag}")


### PR DESCRIPTION
I realized after I went to setup the Pipeline job for this project that I would
be effectively resetting the BUILD_NUMBER. One of the many reasons the Git
commit SHA1 is more portable/correct when compared to a job's BUILD_NUMBER
