### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
     pipelineTriggers([[$class:"SCMTrigger", scmpoll_spec:"H/15 * * * *"]]),
 ])
 
-node('docker') {
+node('docker&&linux') {
     stage('Checkout') {
         checkout scm
     }


### PR DESCRIPTION
When Windows docker agents available, make sure this only runs on Linux docker agents.